### PR TITLE
Added cloud-datastore-emulator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ RUN apt update && apt install -y scala
 RUN apt update && apt install -y ruby-sass && gem install foreman
 RUN curl -sSL https://sdk.cloud.google.com | bash
 ENV PATH=$PATH:/root/google-cloud-sdk/bin
-RUN gcloud components install app-engine-java
+RUN gcloud components install app-engine-java beta cloud-datastore-emulator


### PR DESCRIPTION
GAEのDatastore APIからCloud Datastore APIへの移行でテストに使用するため、Cloud Datastore Emulatorをイメージに追加します。

https://cloud.google.com/datastore/docs/tools/datastore-emulator

Emulatorの起動に`beta`コマンドも必要なため合わせて入れています。
