### PR TITLE
使用していないsbtのインストールをやめ、scalaパッケージを単体でインストールする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,21 @@
 FROM maven:3-jdk-8
-RUN apt update && apt install -y apt-transport-https unzip bc
-RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/apt/sources.list.d/sbt.list
-RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee /etc/apt/sources.list.d/sbt_old.list
-RUN curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add
-RUN apt update && apt install -y sbt
-RUN apt update && apt install -y ruby-sass && gem install foreman
-RUN curl -sSL https://sdk.cloud.google.com | bash
+
 ENV PATH=$PATH:/root/google-cloud-sdk/bin
-RUN gcloud components install app-engine-java beta cloud-datastore-emulator
+
+RUN set -eux; \
+        apt-get update -qq; \
+        apt-get install -yq \
+            apt-transport-https \
+            unzip \
+            bc \
+            scala \
+            ruby-sass; \
+        gem install foreman; \
+        curl -sSL https://sdk.cloud.google.com | bash; \
+        gcloud components install app-engine-java beta cloud-datastore-emulator; \
+        apt-get clean; \
+        rm -rf /var/cache/apt/archives/* \
+               /var/lib/apt/lists/* \
+               /tmp/*; \
+        truncate -s 0 /var/log/*log;
+

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ included below
 
 - JDK ver.8
 - maven ver.3
-- sbt
+- scala
 - ruby-sass
 - google-cloud-sdk
 


### PR DESCRIPTION
使用していないsbtのインストールをやめ、scalaパッケージを単体でインストールする

他の変更点は、以下の通りです。
* sbt関連のaptソースの追加（現状の記述だとエラー）をやめる
* aptコマンドをapt-getに変更
* set -euxと;でビルドを見やすくする
* 改行挟むことでaptパッケージの追加削除を今後わかりやすくする
* 簡単なゴミ掃除（ローカルの圧縮前イメージで2.8GB→2.78GB）

なお現在のmainを、sbt関連を削除&scalaに変更、としたのが以下のDockerfileだがこのイメージをビルドすると3.97GB
```dockerfile
FROM maven:3-jdk-8
RUN apt-get update && apt-get install -y apt-transport-https unzip bc
RUN apt-get update && apt-get install -y scala
RUN apt-get update && apt-get install -y ruby-sass && gem install foreman
RUN curl -sSL https://sdk.cloud.google.com | bash
ENV PATH=$PATH:/root/google-cloud-sdk/bin
RUN gcloud components install app-engine-java beta cloud-datastore-emulator
```

## 連絡事項

* 試しに--no-install-recommendsをつけると2.71GBでした。差分のパッケージは以下です。
  ```
  alsa-topology-conf/now 1.2.4-1 all [installed,local]
  alsa-ucm-conf/now 1.2.4-2 all [installed,local]
  dbus/now 1.12.24-0+deb11u1 amd64 [installed,local]
  fonts-lato/now 2.0-2.1 all [installed,local]
  javascript-common/now 11+nmu1 all [installed,local]
  libapparmor1/now 2.13.6-10 amd64 [installed,local]
  libglib2.0-data/now 2.66.8-1 all [installed,local]
  libicu67/now 67.1-7 amd64 [installed,local]
  libjs-jquery/now 3.5.1+dfsg+~3.5.5-7 all [installed,local]
  libxml2/now 2.9.10+dfsg-6.7+deb11u4 amd64 [installed,local]
  shared-mime-info/now 2.0-1 amd64 [installed,local]
  xdg-user-dirs/now 0.17-2 amd64 [installed,local]
  zip/now 3.0-12 amd64 [installed,local]
  ```
  多分だいじょうぶだから別PR作ったらとか、意見あったらいただきたいです
* 一つのRUNにまとめたのは、aptの変更などでビルドできなくなるのに早く気付くのと、頻繁に変更するものでもないためこの程度ならビルドキャッシュなくてもいいかな、と思ったからです。ここは分けてはどう？などあったら意見いただきたいです
* Dockerイメージ`ghcr.io/ubiregiinc/jdk8-scala-appengine:cloud-datastore-emulator-v2`を公開しました
  1. このブランチをcheckout
  2. https://github.com/settings/tokens/new
      から`write:packages`に権限をつけたトークンを生成して、token.txtに保存
  3. buildxでビルド、プッシュ
     ```sh
     cat token.txt | docker login ghcr.io -u hsato23 --password-stdin
     docker buildx create --use
     docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/ubiregiinc/jdk8-scala-appengine:cloud-datastore-emulator-v2 --push .
     docker buildx rm #普段使わないので
     ```
  4. https://github.com/settings/tokens で2のトークン削除（普段使わないので）



